### PR TITLE
Migrate daisyUI tooltip to shadcn tooltip

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,14 +46,6 @@
     @apply font-mont text-base font-bold tracking-widest text-black-200 dark:text-white-400 xl:text-xl;
   }
 
-  .dropdown-link {
-    @apply cursor-pointer py-2.5 pl-4 font-mont font-semibold tracking-widest text-black-200 transition duration-200 hover:bg-white-300 hover:text-aqua dark:text-white-200 dark:hover:bg-black-400 dark:hover:text-orange;
-  }
-
-  .profilePic {
-    @apply mx-auto mb-8 h-72 w-48 object-scale-down object-center shadow-dropdown dark:shadow-none md:order-last md:col-span-1 md:row-start-1 md:row-end-4 md:mb-0 md:mr-0 md:h-5/6 md:w-full md:object-cover lg:self-center xl:col-span-2 xl:w-9/12 2xl:z-10;
-  }
-
   .span-heading {
     @apply ml-3 bg-transparent bg-gradient-to-r from-blue to-blue bg-clip-text text-transparent transition-bgi duration-300 ease-out dark:bg-dance-to-forget;
   }
@@ -78,15 +70,11 @@
     @apply mb-2 transition-colors duration-300 ease-out dark:text-white-300 md:text-2xl xl:mb-4 xl:text-3xl;
   }
 
-  .experience-animation {
-    @apply hidden h-44 w-44 lg:col-start-3  lg:col-end-4 lg:row-start-1 lg:row-end-5 lg:block lg:h-[14rem] lg:w-[14rem] lg:place-self-center xl:h-[18rem] xl:w-[18rem];
+  .tooltip-content {
+    @apply select-none rounded bg-aqua px-1.5 py-2.5 text-base text-white-400 shadow-tooltip transition duration-[400ms] ease-tooltip will-change-tooltip dark:bg-orange dark:text-black-300 md:px-2.5;
   }
 
-  .project-image-container {
-    @apply absolute top-0 left-0 -z-10 h-full max-h-[670px] w-full max-w-[670px] opacity-[8%] md:top-1/4 md:h-1/2 md:w-1/2 md:border-2 md:border-black-200 md:opacity-60 dark:md:opacity-30 lg:top-[12.5%] lg:h-3/4 lg:w-1/2;
-  }
-
-  .footer-container {
-    @apply mx-auto flex h-full w-11/12 max-w-7xl flex-col flex-nowrap items-start justify-between gap-y-2 py-4 md:flex-row md:items-center md:gap-y-0 lg:py-8;
+  .tooltip-arrow {
+    @apply fill-aqua dark:fill-orange;
   }
 }

--- a/components/HeroButtons.tsx
+++ b/components/HeroButtons.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { externalLinks } from '@/constants/global';
 import { useThemeContext } from '@/hooks/useThemeContext';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 const HeroButtons = () => {
   const { darkMode } = useThemeContext() ?? false;
@@ -9,27 +10,31 @@ const HeroButtons = () => {
   const anchorElements = Object.entries(externalLinks).map(
     ([name, { Icon, url }]) => {
       return (
-        <div
-          key={name}
-          className="tooltip tooltip-bottom tooltip-info ml-2 dark:tooltip-warning md:tooltip-top md:ml-0"
-          data-tip={name}
-        >
-          <Link aria-label={name} href={url} rel="noreferrer" target="_blank">
-            <Icon
-              size={40}
-              color={`${darkMode ? '#DEE2E6' : '#343434'}`}
-              className="cursor-pointer"
-              data-testid={name}
-            />
-          </Link>
-        </div>
+        <Tooltip.Root key={name}>
+          <Tooltip.Trigger asChild>
+            <Link aria-label={name} href={url} rel="noreferrer" target="_blank">
+              <Icon
+                size={40}
+                color={`${darkMode ? '#DEE2E6' : '#343434'}`}
+                className="cursor-pointer"
+                data-testid={name}
+              />
+            </Link>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content className="animate-slideDownAndFade tooltip-content">
+              {name}
+              <Tooltip.Arrow className="tooltip-arrow" />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
       );
     }
   );
 
   return (
     <div className="flex flex-row items-center justify-start gap-x-6">
-      {anchorElements}
+      <Tooltip.Provider delayDuration={400}>{anchorElements}</Tooltip.Provider>
       <button type="button" className="redirect-button">
         <Link
           aria-label="resume pdf"

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { useThemeContext } from '@/hooks/useThemeContext';
+import { clsx } from 'clsx';
+import { LazyMotion, domAnimation, m } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
-import { Tproject } from '@/sections/projects/projectDetails';
-import { LazyMotion, domAnimation, m } from 'framer-motion';
 import { Tanimation } from '@/constants/typeInterface';
+import { useThemeContext } from '@/hooks/useThemeContext';
+import { Tproject } from '@/sections/projects/projectDetails';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 const ProjectCard = ({
   id,
@@ -17,31 +19,37 @@ const ProjectCard = ({
 }: Tproject & { animation: Tanimation }) => {
   const { darkMode } = useThemeContext() ?? false;
   const iconColor = darkMode ? '#DEE2E6' : '#343434';
+  const checkId = id % 2 === 0;
+  const colPlacement = checkId
+    ? 'md:col-start-1 md:col-end-7'
+    : 'md:col-start-6 md:col-end-13';
 
   const createProjectIcons = (
     iconList: Tproject['stack'] | Tproject['links']
   ) =>
     iconList.map((icon) => (
-      <div
-        key={icon.tooltipText}
-        className={`tooltip tooltip-top tooltip-info dark:tooltip-warning ${
-          icon?.url ? 'cursor-pointer' : 'cursor-default'
-        }`}
-        data-tip={icon.tooltipText}
-      >
-        {iconList === stack ? (
-          <icon.Icon key={icon.tooltipText} size={35} color={iconColor} />
-        ) : (
-          <Link
-            aria-label={icon.tooltipText}
-            href={icon.url as string}
-            rel="noreferrer"
-            target="_blank"
-          >
+      <Tooltip.Root key={icon.tooltipText}>
+        <Tooltip.Trigger asChild>
+          {iconList === stack ? (
             <icon.Icon key={icon.tooltipText} size={35} color={iconColor} />
-          </Link>
-        )}
-      </div>
+          ) : (
+            <Link
+              aria-label={icon.tooltipText}
+              href={icon.url as string}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <icon.Icon key={icon.tooltipText} size={35} color={iconColor} />
+            </Link>
+          )}
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className="animate-slideDownAndFade tooltip-content">
+            {icon.tooltipText}
+            <Tooltip.Arrow className="tooltip-arrow" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
     ));
 
   return (
@@ -53,31 +61,26 @@ const ProjectCard = ({
         viewport={{ once: true, amount: 0.7 }}
         className="relative z-0 mb-5 list-none"
       >
-        <li className="grid grid-rows-1 rounded-lg px-5 py-4 shadow-project transition-transform duration-300 ease-out hover:-translate-y-2 md:grid-cols-12 md:grid-rows-5 md:items-center md:justify-items-center md:rounded-none md:shadow-none md:transition-none md:hover:translate-y-0">
+        <li
+          className={clsx(
+            'grid grid-rows-1 rounded-lg px-5 py-4 shadow-project',
+            'transition-transform duration-300 ease-out hover:-translate-y-2',
+            'md:grid-cols-12 md:grid-rows-5 md:items-center md:justify-items-center',
+            'md:rounded-none md:shadow-none md:transition-none md:hover:translate-y-0'
+          )}
+        >
           <h3
-            className={`white-sub-heading font-bold tracking-wide dark:text-[#FFA54E] md:row-start-1 md:row-end-2 md:mb-0 ${
-              id % 2 === 0
-                ? 'md:col-start-1 md:col-end-7'
-                : 'md:col-start-6 md:col-end-13'
-            }`}
+            className={`white-sub-heading font-bold tracking-wide dark:text-[#FFA54E] md:row-start-1 md:row-end-2 md:mb-0 ${colPlacement}`}
           >
             {projectTitle}
           </h3>
           <p
-            className={`mb-2 text-sm transition-colors duration-300 ease-out dark:bg-none dark:text-white-100 md:row-start-2 md:row-end-4 md:bg-white-400 md:p-4 md:text-lg md:shadow-project dark:md:bg-black-500 dark:md:shadow-xl xl:text-xl ${
-              id % 2 === 0
-                ? 'md:col-start-1 md:col-end-7'
-                : 'md:col-start-6 md:col-end-13'
-            }`}
+            className={`mb-2 text-sm transition-colors duration-300 ease-out dark:bg-none dark:text-white-100 md:row-start-2 md:row-end-4 md:bg-white-400 md:p-4 md:text-lg md:shadow-project dark:md:bg-black-500 dark:md:shadow-xl xl:text-xl ${colPlacement}`}
           >
             {projectDesc}
           </p>
           <div
-            className={`row-span-1 mb-2 md:row-start-4 md:row-end-5 ${
-              id % 2 === 0
-                ? 'md:col-start-1 md:col-end-7'
-                : 'md:col-start-6 md:col-end-13'
-            }`}
+            className={`row-span-1 mb-2 md:row-start-4 md:row-end-5 ${colPlacement}`}
           >
             <h4 className="mb-2 font-semibold text-black-200 dark:text-white-500 md:text-center md:text-lg lg:text-xl xl:text-2xl">
               Tech Stack
@@ -87,11 +90,7 @@ const ProjectCard = ({
             </div>
           </div>
           <div
-            className={`row-span-1 mb-2 md:row-start-5 md:row-end-6 ${
-              id % 2 === 0
-                ? 'md:col-start-1 md:col-end-7'
-                : 'md:col-start-6 md:col-end-13'
-            }`}
+            className={`row-span-1 mb-2 md:row-start-5 md:row-end-6 ${colPlacement}`}
           >
             <h4 className="mb-2 font-semibold text-black-200 transition-colors duration-300 ease-out dark:text-white-500 md:text-center md:text-lg lg:text-xl xl:text-2xl">
               Links
@@ -101,9 +100,15 @@ const ProjectCard = ({
             </div>
           </div>
           <aside
-            className={`project-image-container ${
-              id % 2 === 0 ? 'md:left-[45%]' : 'md:left-0'
-            }`}
+            className={clsx(
+              'absolute left-0 top-0 -z-10 h-full max-h-[670px] w-full',
+              'max-w-[670px] opacity-[8%] md:top-1/4 md:h-1/2 md:w-1/2',
+              'md:border-2 md:border-black-200 md:opacity-60 dark:md:opacity-30',
+              'md:left-0 lg:top-[12.5%] lg:h-3/4 lg:w-1/2',
+              {
+                'md:left-[45%]': checkId,
+              }
+            )}
           >
             <Image
               src={image}

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@radix-ui/react-tooltip": "1.0.5",
     "@svgr/webpack": "7.0.0",
     "@tabler/icons-react": "2.17.0",
     "@types/node": "18.16.3",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.1",
+    "clsx": "1.2.1",
     "daisyui": "2.51.6",
     "framer-motion": "10.12.4",
     "lottie-light-react": "2.4.0",

--- a/sections/experience/Experience.tsx
+++ b/sections/experience/Experience.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import React, { lazy } from 'react';
+import { clsx } from 'clsx';
+import Animation from '../../components/Animation';
+import { m } from 'framer-motion';
+import ExperienceLottie from '../../public/animations/experience.json';
+import JobPointers from './JobPointers';
+import { Tanimation } from '@/constants/typeInterface';
 import { useMotionContext } from '@/hooks/useMotionContext';
 import { useRefsContext } from '@/hooks/useRefsContext';
-import JobPointers from './JobPointers';
-import ExperienceLottie from '../../public/animations/experience.json';
-import { m } from 'framer-motion';
-import { Tanimation } from '@/constants/typeInterface';
-import Animation from '../../components/Animation';
 
 const Lottie = lazy(() => import('lottie-light-react'));
 
@@ -42,7 +43,11 @@ const Experience = () => {
     <section className="dark-blue-section">
       <Animation
         animation={containerAnimation}
-        className="dark-blue-container mb-40 md:mb-72 md:grid-rows-5 md:items-center md:justify-center md:gap-x-10 md:gap-y-0 md:pt-0 lg:mb-[22rem] xl:mb-80 2xl:mb-[26rem] 3xl:mb-[22rem]"
+        className={clsx(
+          'dark-blue-container mb-40 md:mb-72 md:grid-rows-5',
+          'md:items-center md:justify-center md:gap-x-10 md:gap-y-0',
+          'md:pt-0 lg:mb-[22rem] xl:mb-80 2xl:mb-[26rem] 3xl:mb-[22rem]'
+        )}
         viewAmount={0.65}
       >
         <m.h2
@@ -53,7 +58,14 @@ const Experience = () => {
           🧑‍💻<span className="span-heading">Experience</span>
         </m.h2>
         <JobPointers childAnimation={childAnimation} />
-        <m.aside variants={lottieAnimation} className="experience-animation">
+        <m.aside
+          variants={lottieAnimation}
+          className={clsx(
+            'hidden h-44 w-44 lg:col-start-3 lg:col-end-4 lg:row-start-1',
+            'lg:row-end-5 lg:block lg:h-[14rem] lg:w-[14rem]',
+            'lg:place-self-center xl:h-[18rem] xl:w-[18rem]'
+          )}
+        >
           <Lottie
             animationData={ExperienceLottie}
             loop={prefersReducedMotion ? 1 : true}

--- a/sections/footer/Footer.tsx
+++ b/sections/footer/Footer.tsx
@@ -28,7 +28,7 @@ const Footer = () => {
 
   return (
     <footer>
-      <div className="footer-container">
+      <div className="mx-auto flex h-full w-11/12 max-w-7xl flex-col flex-nowrap items-start justify-between gap-y-2 py-4 md:flex-row md:items-center md:gap-y-0 lg:py-8">
         <h4 className="text-base font-medium text-black-200 dark:text-white-300 md:order-first md:text-lg xl:text-xl ">
           Designed & Built by Nicholas Yong
         </h4>

--- a/sections/hero/Hero.tsx
+++ b/sections/hero/Hero.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import React from 'react';
+import { clsx } from 'clsx';
+import { motion } from 'framer-motion';
 import Image from 'next/image';
 import profilePic from '../../public/images/profile-light.webp';
 import HeroButtons from '../../components/HeroButtons';
 import { useMotionContext } from '@/hooks/useMotionContext';
-import { motion } from 'framer-motion';
 import { Tanimation } from '@/constants/typeInterface';
 
 const Hero = () => {
@@ -39,12 +40,16 @@ const Hero = () => {
       viewport={{ once: true, amount: 0.65 }}
       className="mx-auto mb-28 grid w-11/12 max-w-7xl grid-cols-1 pt-32 md:grid-cols-3 md:grid-rows-3 md:items-center md:justify-evenly md:gap-x-8 md:pt-60 lg:mb-60 xl:grid-cols-4"
     >
-      <motion.aside variants={childAnimation} className='profilePic'>
-        <Image
-          src={profilePic}
-          alt="Profile Picture"
-          priority
-        />
+      <motion.aside
+        variants={childAnimation}
+        className={clsx(
+          'mx-auto mb-8 h-72 w-48 object-scale-down object-center',
+          'shadow-dropdown dark:shadow-none md:order-last md:col-span-1',
+          'md:row-start-1 md:row-end-4 md:mb-0 md:mr-0 md:h-5/6 md:w-full',
+          'md:object-cover lg:self-center xl:col-span-2 xl:w-9/12 2xl:z-10'
+        )}
+      >
+        <Image src={profilePic} alt="Profile Picture" priority />
       </motion.aside>
       <motion.h1
         variants={childAnimation}

--- a/sections/navbar/DropdownUl.tsx
+++ b/sections/navbar/DropdownUl.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { useMotionContext } from '@/hooks/useMotionContext';
-import { useRefsContext } from '@/hooks/useRefsContext';
+import { clsx } from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
 import { HamburgerProps } from '@/constants/typeInterface';
 import { scrollToRef } from '@/constants/global';
 import { listElements } from '@/constants/global';
+import { useMotionContext } from '@/hooks/useMotionContext';
+import { useRefsContext } from '@/hooks/useRefsContext';
 
 const DropdownUl = ({ isMenuClicked, setMenuClicked }: HamburgerProps) => {
   const { prefersReducedMotion } = useMotionContext() ?? false;
@@ -26,13 +27,15 @@ const DropdownUl = ({ isMenuClicked, setMenuClicked }: HamburgerProps) => {
           scrollToRef(refsArray[index], prefersReducedMotion ?? false);
           setMenuClicked((prevState) => !prevState);
         }}
-        className={`dropdown-link ${
-          index === 0
-            ? 'rounded-t-xl'
-            : index === lastElement
-            ? 'rounded-b-xl p-0'
-            : 'rounded-none'
-        }`}
+        className={clsx(
+          'cursor-pointer py-2.5 pl-4 font-mont font-semibold tracking-widest',
+          'text-black-200 transition duration-200 hover:bg-white-300 hover:text-aqua',
+          'rounded-none dark:text-white-200 dark:hover:bg-black-400 dark:hover:text-orange',
+          {
+            'rounded-t-xl': index === 0,
+            'rounded-b-xl py-0 pl-0': index === lastElement,
+          }
+        )}
       >
         {index === lastElement ? (
           <a
@@ -40,7 +43,12 @@ const DropdownUl = ({ isMenuClicked, setMenuClicked }: HamburgerProps) => {
             href="https://drive.google.com/file/d/1kRKuXcY7BFh2te6BMJLDYogwU3V29dba/view?usp=sharing"
             rel="noreferrer"
             target="_blank"
-            className="redirect-button block h-full w-full rounded-t-none rounded-b-xl bg-aqua py-2.5 pl-4 font-bold text-white-400 transition-colors duration-300 ease-out hover:bg-dark-aqua hover:no-underline dark:text-black-300"
+            className={clsx(
+              'redirect-button block h-full w-full rounded-t-none',
+              'rounded-b-xl bg-aqua py-2.5 pl-4 font-bold text-white-400',
+              'transition-colors duration-300 ease-out hover:bg-dark-aqua',
+              'hover:no-underline dark:text-black-300'
+            )}
           >
             {element}
           </a>
@@ -59,7 +67,7 @@ const DropdownUl = ({ isMenuClicked, setMenuClicked }: HamburgerProps) => {
           animate={{ x: 0 }}
           exit={{ x: '-100vw' }}
           transition={transitionType}
-          className="absolute top-12 left-0 z-50 w-full max-w-sm"
+          className="absolute left-0 top-12 z-50 w-full max-w-sm"
           data-testid="dropdown-ul"
         >
           <ul className="rounded-xl bg-white-400 shadow-dropdown dark:bg-black-500 dark:shadow-none">

--- a/sections/projects/Projects.tsx
+++ b/sections/projects/Projects.tsx
@@ -7,6 +7,7 @@ import ProjectCard from '@/components/ProjectCard';
 import { projectCards } from './projectDetails';
 import Animation from '@/components/Animation';
 import { Tanimation } from '@/constants/typeInterface';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 const Projects = () => {
   const { prefersReducedMotion } = useMotionContext() ?? false;
@@ -46,7 +47,7 @@ const Projects = () => {
             Coding projects that I enjoyed working on.
           </h3>
         </Animation>
-        {displayCards}
+        <Tooltip.Provider delayDuration={400}>{displayCards}</Tooltip.Provider>
       </div>
     </section>
   );

--- a/sections/skills/SkillCategory.tsx
+++ b/sections/skills/SkillCategory.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { useThemeContext } from '@/hooks/useThemeContext';
+import { clsx } from 'clsx';
 import { averageDesignIcons, goodDesignIcons, TIcons } from './common';
-import { Tvariants } from '@/constants/typeInterface';
 import { m } from 'framer-motion';
+import { Tvariants } from '@/constants/typeInterface';
+import { useThemeContext } from '@/hooks/useThemeContext';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 const SkillCategory = ({
   heading,
@@ -11,7 +13,8 @@ const SkillCategory = ({
   childAnimation,
 }: TIcons & Tvariants) => {
   const { darkMode } = useThemeContext() ?? false;
-  const tooltipColor = darkMode ? 'tooltip-warning' : 'tooltip-info';
+  const tooltipSide =
+    icons === goodDesignIcons || icons === averageDesignIcons ? 'right' : 'top';
   const iconColor = darkMode ? '#DEE2E6' : '#343434';
 
   return (
@@ -25,17 +28,28 @@ const SkillCategory = ({
       >
         {icons.map(({ Icon, tooltipText: tooltipText }) => {
           return (
-            <m.div
-              variants={childAnimation}
-              key={tooltipText}
-              className={`tooltip ${tooltipColor} ${
-                icons === goodDesignIcons || icons === averageDesignIcons
-                  ? 'tooltip-right'
-                  : 'tooltip-top'
-              }`}
-              data-tip={tooltipText}
-            >
-              <Icon key={tooltipText} size={40} color={iconColor} />
+            <m.div variants={childAnimation} key={tooltipText}>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <Icon key={tooltipText} size={40} color={iconColor} />
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    side={tooltipSide}
+                    className={clsx(
+                      'animate-slideDownAndFade tooltip-content',
+                      {
+                        'animate-slideLeftAndFade':
+                          icons === goodDesignIcons ||
+                          icons === averageDesignIcons,
+                      }
+                    )}
+                  >
+                    {tooltipText}
+                    <Tooltip.Arrow className="tooltip-arrow" />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
             </m.div>
           );
         })}

--- a/sections/skills/Skills.tsx
+++ b/sections/skills/Skills.tsx
@@ -16,6 +16,7 @@ import SkillsDark from '../../public/animations/skills-dark.json';
 import Animation from '../../components/Animation';
 import { m } from 'framer-motion';
 import { Tanimation } from '@/constants/typeInterface';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 const Lottie = lazy(() => import('lottie-light-react'));
 
@@ -68,36 +69,38 @@ const Skills = () => {
             Skills
           </span>
         </m.h2>
-        <m.div variants={containerAnimation}>
-          <h3 className="white-sub-heading font-semibold dark:text-[#FFA54E]">
-            I am not that bad with:
-          </h3>
-          <SkillCategory
-            heading="coding"
-            icons={goodCodingIcons}
-            {...animationProps}
-          />
-          <SkillCategory
-            heading="design"
-            icons={goodDesignIcons}
-            {...animationProps}
-          />
-        </m.div>
-        <m.div variants={containerAnimation}>
-          <h3 className="white-sub-heading font-semibold dark:text-[#FFA54E]">
-            I have played around with:
-          </h3>
-          <SkillCategory
-            heading="coding"
-            icons={averageCodingIcons}
-            {...animationProps}
-          />
-          <SkillCategory
-            heading="design"
-            icons={averageDesignIcons}
-            {...animationProps}
-          />
-        </m.div>
+        <Tooltip.Provider delayDuration={400}>
+          <m.div variants={containerAnimation}>
+            <h3 className="white-sub-heading font-semibold dark:text-[#FFA54E]">
+              I am not that bad with:
+            </h3>
+            <SkillCategory
+              heading="coding"
+              icons={goodCodingIcons}
+              {...animationProps}
+            />
+            <SkillCategory
+              heading="design"
+              icons={goodDesignIcons}
+              {...animationProps}
+            />
+          </m.div>
+          <m.div variants={containerAnimation}>
+            <h3 className="white-sub-heading font-semibold dark:text-[#FFA54E]">
+              I have played around with:
+            </h3>
+            <SkillCategory
+              heading="coding"
+              icons={averageCodingIcons}
+              {...animationProps}
+            />
+            <SkillCategory
+              heading="design"
+              icons={averageDesignIcons}
+              {...animationProps}
+            />
+          </m.div>
+        </Tooltip.Provider>
         <m.aside
           variants={lottieAnimation}
           className="hidden h-56 w-56 md:absolute md:bottom-20 md:right-28 md:block dark:md:right-10 lg:bottom-40 lg:right-5 lg:h-[22rem] lg:w-[22rem] dark:lg:h-[17rem] dark:lg:w-[17rem] xl:h-[28rem] xl:w-[28rem] dark:xl:h-[23rem] dark:xl:w-[23rem]"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,6 +56,8 @@ module.exports = {
           'rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px',
         project:
           'rgba(6, 24, 44, 0.4) 0px 0px 0px 2px, rgba(6, 24, 44, 0.65) 0px 4px 6px -1px, rgba(255, 255, 255, 0.08) 0px 1px 0px inset',
+        tooltip:
+          ' hsl(206 22% 7% / 35%) 0 10px 38px -10px, hsl(206 22% 7% / 20%) 0 10px 20px -15px',
       },
       backgroundImage: {
         'orange-gradient': 'linear-gradient(to right, #f46b45, #eea849)',
@@ -69,16 +71,30 @@ module.exports = {
           '20%': { transform: 'rotate(-6deg)' },
           '40%': { transform: 'rotate(-4deg)' },
         },
+        slideDownAndFade: {
+          '0%': { opacity: 0, transform: 'translateX(-2px)' },
+          '100%': { opacity: 1, transform: 'translateX(0)' },
+        },
+        slideLeftAndFade: {
+          '0%': { opacity: 0, transform: 'translateX(2px)' },
+          '100%': { opacity: 1, transform: 'translateX(0)' },
+        },
       },
       screens: {
         'ipad-mini': '650px',
       },
-      transformOrigin: {
-        wave: '70% 70%',
-      },
       transitionProperty: {
         bgi: 'background-image',
         top: 'top',
+      },
+      transformOrigin: {
+        wave: '70% 70%',
+      },
+      transitionTimingFunction: {
+        tooltip: 'cubic-bezier(0.16, 1, 0.3, 1)',
+      },
+      willChange: {
+        tooltip: 'transform, opacity',
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1566,6 +1566,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.13.10":
+  version: 7.21.5
+  resolution: "@babel/runtime@npm:7.21.5"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 358f2779d3187f5c67ad302e8f8d435412925d0b991d133c7d4a7b1ddd5a3fda1b6f34537cb64628dfd96a27ae46df105bed3895b8d754b88cacdded8d1129dd
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.18.10, @babel/template@npm:^7.20.7, @babel/template@npm:^7.3.3":
   version: 7.20.7
   resolution: "@babel/template@npm:7.20.7"
@@ -1697,6 +1706,35 @@ __metadata:
   version: 8.39.0
   resolution: "@eslint/js@npm:8.39.0"
   checksum: 63fe36e2bfb5ff5705d1c1a8ccecd8eb2f81d9af239713489e767b0e398759c0177fcc75ad62581d02942f2776903a8496d5fae48dc2d883dff1b96fcb19e9e2
+  languageName: node
+  linkType: hard
+
+"@floating-ui/core@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@floating-ui/core@npm:0.7.3"
+  checksum: f48f9fb0d19dcbe7a68c38e8de7fabb11f0c0e6e0ef215ae60b5004900bacb1386e7b89cb377d91a90ff7d147ea1f06c2905136ecf34dea162d9696d8f448d5f
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^0.5.3":
+  version: 0.5.4
+  resolution: "@floating-ui/dom@npm:0.5.4"
+  dependencies:
+    "@floating-ui/core": ^0.7.3
+  checksum: 9f9d8a51a828c6be5f187204aa6d293c6c9ef70d51dcc5891a4d85683745fceebf79ff8826d0f75ae41b45c3b138367d339756f27f41be87a8770742ebc0de42
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:0.7.2":
+  version: 0.7.2
+  resolution: "@floating-ui/react-dom@npm:0.7.2"
+  dependencies:
+    "@floating-ui/dom": ^0.5.3
+    use-isomorphic-layout-effect: ^1.1.1
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: bc3f2b5557f87f6f4bbccfe3e8d097abafad61a41083d3b79f3499f27590e273bcb3dc7136c2444841ee7a8c0d2a70cc1385458c16103fa8b70eade80c24af52
   languageName: node
   linkType: hard
 
@@ -2203,6 +2241,269 @@ __metadata:
     tiny-glob: ^0.2.9
     tslib: ^2.4.0
   checksum: 118a1971120253740121a1db0a6658c21195b7da962acf9c124b507a3df707cfc97b0b84a16edcbd4352853b182e8337da9fc6e8e3d06c60d75ae4fb42321c75
+  languageName: node
+  linkType: hard
+
+"@radix-ui/primitive@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/primitive@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+  checksum: 72996afaf346ec4f4c73422f14f6cb2d0de994801ba7cbb9a4a67b0050e0cd74625182c349ef8017ccae1406579d4b74a34a225ef2efe61e8e5337decf235deb
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-arrow@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@radix-ui/react-arrow@npm:1.0.2"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-primitive": 1.0.2
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: d9c4a810376b686edfedfab15c3ef739bb2b388211fbf33191648149aba5064bfff8a5de05b264ad0b76c4a4df98fd8267002580e3515b7f5ad31b9495bfda21
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-compose-refs@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-compose-refs@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: fb98be2e275a1a758ccac647780ff5b04be8dcf25dcea1592db3b691fecf719c4c0700126da605b2f512dd89caa111352b9fad59528d736b4e0e9a0e134a74a1
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-context@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: 43c6b6f2183398161fe6b109e83fff240a6b7babbb27092b815932342a89d5ca42aa9806bfae5927970eed5ff90feed04c67aa29c6721f84ae826f17fcf34ce0
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dismissable-layer@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.0
+    "@radix-ui/react-compose-refs": 1.0.0
+    "@radix-ui/react-primitive": 1.0.2
+    "@radix-ui/react-use-callback-ref": 1.0.0
+    "@radix-ui/react-use-escape-keydown": 1.0.2
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: cb2a38a65dd129d1fd58436bedee765f46f6a6edc2ec15d534a1499c10f768ae06ad874704e030c85869b3ee4b61103076a116dfdb7e0c761a8c8cdc30a5c951
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-id@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-id@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-layout-effect": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: ba323cedd6a6df6f6e51ed1f7f7747988ce432b47fd94d860f962b14b342dcf049eae33f8ad0b72fd7df6329a7375542921132271fba64ab0a271c93f09c48d1
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-popper@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-popper@npm:1.1.1"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@floating-ui/react-dom": 0.7.2
+    "@radix-ui/react-arrow": 1.0.2
+    "@radix-ui/react-compose-refs": 1.0.0
+    "@radix-ui/react-context": 1.0.0
+    "@radix-ui/react-primitive": 1.0.2
+    "@radix-ui/react-use-callback-ref": 1.0.0
+    "@radix-ui/react-use-layout-effect": 1.0.0
+    "@radix-ui/react-use-rect": 1.0.0
+    "@radix-ui/react-use-size": 1.0.0
+    "@radix-ui/rect": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: d9be4be002116efa50dc91b4e2e99150cb64db5ac440c4ad85efbd8d36a99615fc316bddae5ccad6a06807242b1ba23ab04e57cf82f5c92f1bcc5d662c77be94
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-portal@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@radix-ui/react-portal@npm:1.0.2"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-primitive": 1.0.2
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: 1165b4bced8057021ea9ac4f568c6e0ea6f190936f07dc96780d67488b9222021444bbb8e04e506eea84d9219a5caacae8d0974e745182d4f398aa903b982e19
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-presence@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-presence@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-compose-refs": 1.0.0
+    "@radix-ui/react-use-layout-effect": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: a607d67795aa265e88f1765dcc7c18bebf6d88d116cb7f529ebe5a3fbbe751a42763aff0c1c89cdd8ce7f7664355936c4070fd3d4685774aff1a80fa95f4665b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@radix-ui/react-primitive@npm:1.0.2"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-slot": 1.0.1
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: 070b1770749eb629425ef959c4cdbd86957b83c5286ae4423e55ab1a89fa286a51f5aeee44e3a13eb6ca44771415ac1acbaeb0ba03013b49ecb5253e1a5a8996
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@radix-ui/react-slot@npm:1.0.1"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-compose-refs": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: a20693f8ce532bd6cbff12ba543dfcf90d451f22923bd60b57dc9e639f6e53348915e182002b33444feb6ab753434e78e2a54085bf7092aadda4418f0423763f
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-tooltip@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@radix-ui/react-tooltip@npm:1.0.5"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.0
+    "@radix-ui/react-compose-refs": 1.0.0
+    "@radix-ui/react-context": 1.0.0
+    "@radix-ui/react-dismissable-layer": 1.0.3
+    "@radix-ui/react-id": 1.0.0
+    "@radix-ui/react-popper": 1.1.1
+    "@radix-ui/react-portal": 1.0.2
+    "@radix-ui/react-presence": 1.0.0
+    "@radix-ui/react-primitive": 1.0.2
+    "@radix-ui/react-slot": 1.0.1
+    "@radix-ui/react-use-controllable-state": 1.0.0
+    "@radix-ui/react-visually-hidden": 1.0.2
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: 621929e92d93e8a6b41fdb780ccf4213578966ff802e06fca005843ba0ea137450035d8ba32acbfb593700cecf608250082f25ec36dd36b4106b3aaae9e7f3f4
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-callback-ref@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-use-callback-ref@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: a8dda76ba0a26e23dc6ab5003831ad7439f59ba9d696a517643b9ee6a7fb06b18ae7a8f5a3c00c530d5c8104745a466a077b7475b99b4c0f5c15f5fc29474471
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-controllable-state@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-callback-ref": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: 35f1e714bbe3fc9f5362a133339dd890fb96edb79b63168a99403c65dd5f2b63910e0c690255838029086719e31360fa92544a55bc902cfed4442bb3b55822e2
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-escape-keydown@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@radix-ui/react-use-escape-keydown@npm:1.0.2"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-callback-ref": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: 5bec1b73ed6c38139bf1db3c626c0474ca6221ae55f154ef83f1c6429ea866280b2a0ba9436b807334d0215bb4389f0b492c65471cf565635957a8ee77cce98a
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: fcdc8cfa79bd45766ebe3de11039c58abe3fed968cb39c12b2efce5d88013c76fe096ea4cee464d42576d02fe7697779b682b4268459bca3c4e48644f5b4ac5e
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-rect@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-use-rect@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/rect": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: c755cee1a8846a74d4f6f486c65134a552c65d0bfb934d1d3d4f69f331c32cfd8b279c08c8907d64fbb68388fc3683f854f336e4f9549e1816fba32156bb877b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-size@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/react-use-size@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-use-layout-effect": 1.0.0
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+  checksum: b319564668512bb5c8c64530e3c12810c4b7c75c19a00d5ef758c246e8d85cd5015df19688e174db1cc44b0584c8d7f22411eb00af5f8ac6c2e789aa5c8e34f5
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-visually-hidden@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@radix-ui/react-visually-hidden@npm:1.0.2"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/react-primitive": 1.0.2
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  checksum: 67c4a55cfad9a8ff519a9b4ce24d2cc9d78c34d08a128a85de1a0a41228fdeb961eaeb4e50ca0d2080c5e31cef6f6e703cb06786579b44e5c66af161b941adb6
+  languageName: node
+  linkType: hard
+
+"@radix-ui/rect@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@radix-ui/rect@npm:1.0.0"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+  checksum: d5b54984148ac52e30c6a92834deb619cf74b4af02709a20eb43e7895f98fed098968b597a715bf5b5431ae186372e65499a801d93e835f53bbc39e3a549f664
   languageName: node
   linkType: hard
 
@@ -3791,6 +4092,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:1.2.1":
+  version: 1.2.1
+  resolution: "clsx@npm:1.2.1"
+  checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
+  languageName: node
+  linkType: hard
+
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -4376,6 +4684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "e-portfolio@workspace:."
   dependencies:
+    "@radix-ui/react-tooltip": 1.0.5
     "@svgr/webpack": 7.0.0
     "@tabler/icons-react": 2.17.0
     "@testing-library/dom": 9.2.0
@@ -4386,6 +4695,7 @@ __metadata:
     "@types/react": 18.2.0
     "@types/react-dom": 18.2.1
     autoprefixer: 10.4.14
+    clsx: 1.2.1
     daisyui: 2.51.6
     eslint: 8.39.0
     eslint-config-next: 13.3.2
@@ -9494,6 +9804,18 @@ __metadata:
     querystringify: ^2.1.1
     requires-port: ^1.0.0
   checksum: fbdba6b1d83336aca2216bbdc38ba658d9cfb8fc7f665eb8b17852de638ff7d1a162c198a8e4ed66001ddbf6c9888d41e4798912c62b4fd777a31657989f7bdf
+  languageName: node
+  linkType: hard
+
+"use-isomorphic-layout-effect@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "use-isomorphic-layout-effect@npm:1.1.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: a6532f7fc9ae222c3725ff0308aaf1f1ddbd3c00d685ef9eee6714fd0684de5cb9741b432fbf51e61a784e2955424864f7ea9f99734a02f237b17ad3e18ea5cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Preview Channel
[Preview URL](https://portfolio-nicholas5538.vercel.app/ 'Preview Deployment URL')

> Please let GitHub actions to finish its check before clicking on it. It shows your changes as if it is on production.
## Describe your changes
1. Refactor / tidy up CSS codes with `clsx`.
2. Install `clsx` and `@radix-ui/react-tooltip`.
3. Change all daisyUI tooltip to shadcn tooltip to reduce bundle size.

Note: daisyUI plugin will be removed in the future once error card has been changed.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Recordings / Screenshots (if any)
